### PR TITLE
Use custom spire-server image with CredentialComposer

### DIFF
--- a/spire/config/k8s/server-configmap.yaml
+++ b/spire/config/k8s/server-configmap.yaml
@@ -50,6 +50,13 @@ data:
         plugin_data {
         }
       }
+
+      CredentialComposer "db" {
+        plugin_cmd = "/opt/spire/bin/dbcredentialcomposer"
+        plugin_data {
+          mysql_spiffe_id_path_prefixes = ["/mysql/client/"]
+        }
+      }
     }
 
     health_checks {

--- a/spire/config/k8s/server-statefulset.yaml
+++ b/spire/config/k8s/server-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: ghcr.io/spiffe/spire-server:1.8.2
+          image: rturner0676/spire-server-mysql-demo:latest
           args:
             - -config
             - /run/spire/config/server.conf


### PR DESCRIPTION
Configure the CredentialComposer plugin to look for the SPIFFE ID path prefix `/mysql/client/` when deciding whether to set the final component of the SPIFFE ID as the Subject CN in workload X.509-SVIDs.

```
time="2023-10-24T20:25:36Z" level=warning msg="Plugin checksum not configured" external=true plugin_name=db plugin_type=CredentialComposer subsystem_name=catalog
time="2023-10-24T20:25:36Z" level=debug msg="starting plugin" args="[/opt/spire/bin/dbcredentialcomposer]" external=true path=/opt/spire/bin/dbcredentialcomposer plugin_name=db plugin_type=CredentialComposer subsystem_name=catalog
time="2023-10-24T20:25:36Z" level=debug msg="plugin started" external=true path=/opt/spire/bin/dbcredentialcomposer pid=13 plugin_name=db plugin_type=CredentialComposer subsystem_name=catalog
time="2023-10-24T20:25:36Z" level=debug msg="waiting for RPC address" external=true path=/opt/spire/bin/dbcredentialcomposer plugin_name=db plugin_type=CredentialComposer subsystem_name=catalog
time="2023-10-24T20:25:36Z" level=debug msg="plugin address" address=/tmp/plugin2893473042 external=true network=unix plugin_name=db plugin_type=CredentialComposer subsystem_name=db.dbcredentialcomposer timestamp="2023-10-24T20:25:36.962Z"
time="2023-10-24T20:25:36Z" level=debug msg="using plugin" external=true plugin_name=db plugin_type=CredentialComposer subsystem_name=catalog version=1
time="2023-10-24T20:25:36Z" level=info msg="Plugin loaded" external=true plugin_name=db plugin_type=CredentialComposer subsystem_name=catalog
```