### PR TITLE
SPIRE registration creation scripts

### DIFF
--- a/spire/config/scripts/create-node-registration-entry.sh
+++ b/spire/config/scripts/create-node-registration-entry.sh
@@ -5,7 +5,6 @@ set -e
 bb=$(tput bold)
 nn=$(tput sgr0)
 
-
 echo "${bb}Creating registration entry for the node...${nn}"
 kubectl exec -n spire spire-server-0 -- \
     /opt/spire/bin/spire-server entry create \

--- a/spire/config/scripts/create-spire-mysql-client-registration-entry.sh
+++ b/spire/config/scripts/create-spire-mysql-client-registration-entry.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+bb=$(tput bold)
+nn=$(tput sgr0)
+
+echo "${bb}Creating registration entry for spire-mysql-client...${nn}"
+kubectl exec -n spire spire-server-0 -- \
+    /opt/spire/bin/spire-server entry create \
+    -spiffeID spiffe://example.org/mysql/client/spire-mysql-client \
+    -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+    -ttl 2m \
+    -hint mysql-client \
+    -selector k8s:ns:default \
+    -selector k8s:pod-label:app:spire-mysql-client

--- a/spire/config/scripts/create-spire-mysql-client-registration-entry.sh
+++ b/spire/config/scripts/create-spire-mysql-client-registration-entry.sh
@@ -10,7 +10,7 @@ kubectl exec -n spire spire-server-0 -- \
     /opt/spire/bin/spire-server entry create \
     -spiffeID spiffe://example.org/mysql/client/spire-mysql-client \
     -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-    -ttl 2m \
+    -x509SVIDTTL 120 \
     -hint mysql-client \
     -selector k8s:ns:default \
     -selector k8s:pod-label:app:spire-mysql-client

--- a/spire/config/scripts/create-spire-mysql-server-registration-entry.sh
+++ b/spire/config/scripts/create-spire-mysql-server-registration-entry.sh
@@ -11,7 +11,7 @@ kubectl exec -n spire spire-server-0 -- \
     /opt/spire/bin/spire-server entry create \
     -spiffeID spiffe://example.org/mysql/server \
     -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-    -ttl 2m \
-    -hint mysql-server
+    -x509SVIDTTL 120 \
+    -hint mysql-server \
     -selector k8s:ns:mysql \
     -selector k8s:pod-label:app:mysql-server

--- a/spire/config/scripts/create-spire-mysql-server-registration-entry.sh
+++ b/spire/config/scripts/create-spire-mysql-server-registration-entry.sh
@@ -11,5 +11,7 @@ kubectl exec -n spire spire-server-0 -- \
     /opt/spire/bin/spire-server entry create \
     -spiffeID spiffe://example.org/mysql/server \
     -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+    -ttl 2m \
+    -hint mysql-server
     -selector k8s:ns:mysql \
     -selector k8s:pod-label:app:mysql-server

--- a/spire/config/scripts/create-spire-mysql-server-registration-entry.sh
+++ b/spire/config/scripts/create-spire-mysql-server-registration-entry.sh
@@ -13,5 +13,6 @@ kubectl exec -n spire spire-server-0 -- \
     -parentID spiffe://example.org/ns/spire/sa/spire-agent \
     -x509SVIDTTL 120 \
     -hint mysql-server \
+    -dns mysql.mysql.svc.cluster.local \
     -selector k8s:ns:mysql \
     -selector k8s:pod-label:app:mysql-server

--- a/spire/config/scripts/create-tls-reloader-registration-entry.sh
+++ b/spire/config/scripts/create-tls-reloader-registration-entry.sh
@@ -10,7 +10,7 @@ kubectl exec -n spire spire-server-0 -- \
     /opt/spire/bin/spire-server entry create \
     -spiffeID spiffe://example.org/mysql/client/tls-reloader \
     -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-    -ttl 2m \
+    -x509SVIDTTL 120 \
     -hint mysql-client \
     -selector k8s:ns:mysql \
     -selector k8s:pod-label:app:mysql-server

--- a/spire/config/scripts/create-tls-reloader-registration-entry.sh
+++ b/spire/config/scripts/create-tls-reloader-registration-entry.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+bb=$(tput bold)
+nn=$(tput sgr0)
+
+echo "${bb}Creating registration entry for tls-reloader...${nn}"
+kubectl exec -n spire spire-server-0 -- \
+    /opt/spire/bin/spire-server entry create \
+    -spiffeID spiffe://example.org/mysql/client/tls-reloader \
+    -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+    -ttl 2m \
+    -hint mysql-client \
+    -selector k8s:ns:mysql \
+    -selector k8s:pod-label:app:mysql-server


### PR DESCRIPTION
Create SPIRE registrations for:
- MySQL server
- MySQL TLS reloader
- Service that is MySQL client

Also consolidate all SPIRE registration entry scripts to one directory to more easily keep track of all of them.