### PR TITLE
Update CredentialComposer plugin path check logic

### DIFF
--- a/config/k8s/mysql/statefulset.yaml
+++ b/config/k8s/mysql/statefulset.yaml
@@ -48,6 +48,10 @@ spec:
             - containerPort: 3306
               name: mysql
           volumeMounts:
+            # mount SPIRE agent socket dir for debugging
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql
             - name: server-certs


### PR DESCRIPTION
- Update CredentialComposer plugin logic to check for path prefix in SPIFFEID
- Tested by pushing to chiragk25/spire-server-mysql-demo and validated cert issued to `tls-reloader` has the correct  `Subject`

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            0f:02:c6:92:5a:84:70:1a:9d:f0:c2:34:7d:f7:37:47
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = US, O = SPIFFE
        Validity
            Not Before: Oct 30 18:39:10 2023 GMT
            Not After : Oct 30 18:41:20 2023 GMT
        Subject: C = US, O = SPIRE, CN = tls-reloader
```