### PR TITLE
Add goose migration scripts for DB init

### DIFF
--- a/pkg/store/init/00001_create_db_users.sql
+++ b/pkg/store/init/00001_create_db_users.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE USER 'mysql-tls-reloader' REQUIRE SUBJECT '/C=US/O=SPIRE/CN=tls-reloader';
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE USER 'spire-mysql-client' REQUIRE SUBJECT '/C=US/O=SPIRE/CN=spire-mysql-client';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP USER 'mysql-tls-reloader';
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP USER 'spire-mysql-client';
+-- +goose StatementEnd

--- a/pkg/store/init/00002_create_app_db.sql
+++ b/pkg/store/init/00002_create_app_db.sql
@@ -7,4 +7,3 @@ CREATE DATABASE spiredemo;
 -- +goose StatementBegin
 DROP DATABASE spiredemo;
 -- +goose StatementEnd
-

--- a/pkg/store/init/00002_create_app_db.sql
+++ b/pkg/store/init/00002_create_app_db.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE DATABASE spiredemo;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP DATABASE spiredemo;
+-- +goose StatementEnd
+

--- a/pkg/store/init/00003_grant_db_user_permissions.sql
+++ b/pkg/store/init/00003_grant_db_user_permissions.sql
@@ -8,8 +8,8 @@ GRANT ALL ON spiredemo.* TO 'spire-mysql-client';
 
 -- +goose Down
 -- +goose StatementBegin
-REVOKE CONNECTION_ADMIN ON *.* TO 'mysql-tls-reloader';
+REVOKE CONNECTION_ADMIN ON *.* FROM 'mysql-tls-reloader';
 -- +goose StatementEnd
 -- +goose StatementBegin
-REVOKE ALL ON spiredemo.* TO 'spire-mysql-client';
+REVOKE ALL ON spiredemo.* FROM 'spire-mysql-client';
 -- +goose StatementEnd

--- a/pkg/store/init/00003_grant_db_user_permissions.sql
+++ b/pkg/store/init/00003_grant_db_user_permissions.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+GRANT CONNECTION_ADMIN ON *.* TO 'mysql-tls-reloader';
+-- +goose StatementEnd
+-- +goose StatementBegin
+GRANT ALL ON spiredemo.* TO 'spire-mysql-client';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+REVOKE CONNECTION_ADMIN ON *.* TO 'mysql-tls-reloader';
+-- +goose StatementEnd
+-- +goose StatementBegin
+REVOKE ALL ON spiredemo.* TO 'spire-mysql-client';
+-- +goose StatementEnd


### PR DESCRIPTION
These scripts run on the default database `mysql`. Tested using -

```
kubectl port-forward mysql-0 -n mysql 3306:3306
```
```
goose mysql "<user:pass>@tcp(127.0.0.1:3306)/mysql?tls=skip-verify" up
```