### PR TITLE
Enable mysql server general logging

### DIFF
--- a/config/k8s/mysql/mysql-config.yaml
+++ b/config/k8s/mysql/mysql-config.yaml
@@ -6,6 +6,8 @@ metadata:
 data:
   mysql.cnf: |-
     [mysqld]
+    general-log=ON
+    general-log-file=/var/lib/mysql/general.log
     ssl-ca=/spire/certs/bundle.0.pem
     ssl-cert=/spire/certs/svid.0.pem
     ssl-key=/spire/certs/svid.0.key


### PR DESCRIPTION
Enable general logging on mysql server, which shows logs along with SSL/TLS related details -
```
% kubectl exec -it mysql-0 -n mysql -c mysql -- cat /var/lib/mysql/general.log                                   
/usr/sbin/mysqld, Version: 8.1.0 (MySQL Community Server - GPL). started with:
Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
Time                 Id Command    Argument
2023-10-30T19:43:21.733461Z	    0 Execute	CREATE TABLE performance_schema.innodb_redo_log_files(
`FILE_ID` BIGINT NOT NULL COMMENT 'Id of the file.',
`FILE_NAME` VARCHAR(2000) NOT NULL COMMENT 'Path to the file.',
`START_LSN` BIGINT NOT NULL COMMENT 'LSN of the first block in the file.',
`END_LSN` BIGINT NOT NULL COMMENT 'LSN after the last block in the file.',
`SIZE_IN_BYTES` BIGINT NOT NULL COMMENT 'Size of the file (in bytes).',
`IS_FULL` TINYINT NOT NULL COMMENT '1 iff file has no free space inside.',
`CONSUMER_LEVEL` INT NOT NULL COMMENT 'All redo log consumers registered on smaller levels than this value, have already consumed this file.'
)engine = 'performance_schema'
2023-10-30T19:43:27.461736Z	    8 Connect	mysql-tls-reloader@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on  using SSL/TLS
2023-10-30T19:43:27.462498Z	    8 Query	ALTER INSTANCE RELOAD TLS
2023-10-30T19:43:27.466463Z	    8 Quit	
2023-10-30T19:43:27.492659Z	    9 Connect	mysql-tls-reloader@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on  using SSL/TLS
2023-10-30T19:43:27.492997Z	    9 Query	ALTER INSTANCE RELOAD TLS
2023-10-30T19:43:27.495392Z	    9 Quit	
2023-10-30T19:44:23.008239Z	   10 Connect	mysql-tls-reloader@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on  using SSL/TLS
2023-10-30T19:44:23.008557Z	   10 Query	ALTER INSTANCE RELOAD TLS
2023-10-30T19:44:23.011878Z	   10 Quit	
2023-10-30T19:44:23.036839Z	   11 Connect	mysql-tls-reloader@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on  using SSL/TLS
2023-10-30T19:44:23.037116Z	   11 Query	ALTER INSTANCE RELOAD TLS
2023-10-30T19:44:23.039253Z	   11 Quit	
2023-10-30T19:45:12.977673Z	   13 Connect	spire-mysql-client@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on spiredemo using SSL/TLS
2023-10-30T19:45:12.978867Z	   13 Query	SELECT * FROM Users
2023-10-30T19:45:17.462269Z	   14 Connect	mysql-tls-reloader@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on  using SSL/TLS
2023-10-30T19:45:17.462680Z	   14 Query	ALTER INSTANCE RELOAD TLS
2023-10-30T19:45:17.467443Z	   14 Quit	
2023-10-30T19:45:17.491456Z	   15 Connect	mysql-tls-reloader@gke-demo-cluster-1-default-pool-05ad9bf6-kfk5.c.core-identity.internal on  using SSL/TLS
2023-10-30T19:45:17.491755Z	   15 Query	ALTER INSTANCE RELOAD TLS
2023-10-30T19:45:17.494483Z	   15 Quit	
2023-10-30T19:45:35.138341Z	   13 Prepare	INSERT INTO Users (name) VALUES ( ? )
2023-10-30T19:45:35.138846Z	   13 Execute	INSERT INTO Users (name) VALUES ( 'David' )
2023-10-30T19:45:35.146486Z	   13 Close stmt
```